### PR TITLE
Passing verb and action to extract body method

### DIFF
--- a/lib/opinionated_http/client.rb
+++ b/lib/opinionated_http/client.rb
@@ -86,14 +86,14 @@ module OpinionatedHTTP
     def get(action:, path: "/#{action}", **args)
       request  = build_request(path: path, verb: "Get", **args)
       response = request(action: action, request: request)
-      extract_body(response)
+      extract_body(response, 'GET', action)
     end
 
     def post(action:, path: "/#{action}", **args)
       request = build_request(path: path, verb: "Post", **args)
 
       response = request(action: action, request: request)
-      extract_body(response)
+      extract_body(response, 'POST', action)
     end
 
     def build_request(verb:, path:, headers: nil, body: nil, form_data: nil, username: nil, password: nil, parameters: nil)
@@ -164,7 +164,7 @@ module OpinionatedHTTP
       response
     end
 
-    def extract_body(response)
+    def extract_body(response, http_method, action)
       return response.body if response.is_a?(Net::HTTPSuccess)
 
       message = "HTTP #{http_method}: #{action} Failure: (#{response.code}) #{response.message}"

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -27,6 +27,16 @@ module OpinionatedHTTP
           end
           assert_equal body, response
         end
+
+        it "fails" do
+          message = "HTTP GET: lookup Failure: (403) Forbidden"
+          error = assert_raises ServiceError do
+            stub_request(Net::HTTPForbidden, 403, "Forbidden", "") do
+              http.get(action: "lookup", parameters: {zip: "12345"})
+            end
+          end
+          assert_equal message, error.message
+        end
       end
 
       describe "post" do
@@ -46,6 +56,29 @@ module OpinionatedHTTP
             http.post(action: "lookup", form_data: output)
           end
           assert_equal body, response
+        end
+
+        it "fails with body" do
+          message = "HTTP POST: lookup Failure: (403) Forbidden"
+          output  = {zip: "12345", population: 54_321}
+          body    = output.to_json
+          error   = assert_raises ServiceError do
+            stub_request(Net::HTTPForbidden, 403, "Forbidden", "") do
+              http.post(action: "lookup", body: body)
+            end
+          end
+          assert_equal message, error.message
+        end
+
+        it "fails with form data" do
+          output  = {zip: "12345", population: 54_321}
+          message = "HTTP POST: lookup Failure: (403) Forbidden"
+          error   = assert_raises ServiceError do
+            stub_request(Net::HTTPForbidden, 403, "Forbidden", "") do
+              http.post(action: "lookup", form_data: output)
+            end
+          end
+          assert_equal message, error.message
         end
       end
 


### PR DESCRIPTION
### Issue # (if available)


### Description of changes
The extract_body method was failing when the HTTP response was not 200 OK because the logging was expecting the http method and action to be available but it was not being passed in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
